### PR TITLE
[API-29608] - Add notify security alerts GHA workflow

### DIFF
--- a/.github/workflows/notify-security-alerts.yml
+++ b/.github/workflows/notify-security-alerts.yml
@@ -1,0 +1,70 @@
+name: Notify Security Alerts
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 15 * * 1-5
+jobs:
+  check_code_scanning_alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      alert_detected: ${{ steps.check.outputs.alert_detected }}
+    steps:
+      - id: check
+        run: |
+          echo ${{ secrets.SANDBOX_ACCESS_FORM_SECURITY_SCAN_WORKFLOW_TOKEN }} | gh auth login --with-token
+          gh api '/repos/department-of-veterans-affairs/va-api-sandbox-access-form/code-scanning/alerts?state=open' \
+            > code-scanning.json
+          cat code-scanning.json
+          if [ "[]" != "$(cat code-scanning.json)" ]; then
+            echo "alert_detected='true'" >> $GITHUB_OUTPUT
+          fi
+
+  check_dependabot_alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      alert_detected: ${{ steps.check.outputs.alert_detected }}
+    steps:
+      - id: check
+        run: |
+          echo ${{ secrets.SANDBOX_ACCESS_FORM_SECURITY_SCAN_WORKFLOW_TOKEN }} | gh auth login --with-token
+          gh api '/repos/department-of-veterans-affairs/va-api-sandbox-access-form/dependabot/alerts?state=open' \
+            > dependabot.json
+          cat dependabot.json
+          if [ "[]" != "$(cat dependabot.json)" ]; then
+            echo "alert_detected='true'" >> $GITHUB_OUTPUT
+          fi
+
+  send_slack_message:
+    runs-on: ubuntu-latest
+    needs: [check_code_scanning_alerts, check_dependabot_alerts]
+    if: needs.check_code_scanning_alerts.outputs.alert_detected || needs.check_dependabot_alerts.outputs.alert_detected
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - id: send_slack_message
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          # This ID is for #team-okapi-alerts in Lighthouse Slack
+          channel-id: C05HL4MTAFR
+          payload: |
+            {
+              "text": "Sandbox Access Form Security Alerts Check",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A security vulnerability alert has been detected in the Sandbox Access Form repository."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@teamokapi please investigate."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Original Issue :: [API-29608](https://jira.devops.va.gov/browse/API-29608)

- Adds GitHub Action workflow for monitoring if security alerts are present in the repo.

Need To ::
- give the `okapi-bot` user the "Security - Read" role in the repo.
- add the `SANDBOX_ACCESS_FORM_SECURITY_SCAN_WORKFLOW_TOKEN` secret to the repo.
- add the `SLACK_BOT_TOKEN` secret to the repo.